### PR TITLE
Add piscigranja management module

### DIFF
--- a/addons/piscigranja/__init__.py
+++ b/addons/piscigranja/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/piscigranja/__manifest__.py
+++ b/addons/piscigranja/__manifest__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+{
+    'name': 'Piscigranja',
+    'version': '0.1',
+    'summary': 'Gestión de piscigranjas',
+    'description': 'Módulo para la gestión integral de piscigranjas.',
+    'author': 'Codex',
+    'depends': ['base', 'mail'],
+    'data': [
+        'security/piscigranja_security.xml',
+        'security/piscigranja_rules.xml',
+        'security/ir.model.access.csv',
+        'views/piscigranja_menus.xml',
+        'views/cycle_views.xml',
+        'views/feed_views.xml',
+        'views/health_views.xml',
+        'views/environment_views.xml',
+    ],
+    'application': True,
+    'license': 'LGPL-3',
+}

--- a/addons/piscigranja/models/__init__.py
+++ b/addons/piscigranja/models/__init__.py
@@ -1,0 +1,4 @@
+from . import cycle
+from . import feed
+from . import health
+from . import environment

--- a/addons/piscigranja/models/cycle.py
+++ b/addons/piscigranja/models/cycle.py
@@ -1,0 +1,38 @@
+from odoo import api, fields, models
+
+class FishBatch(models.Model):
+    _name = 'piscigranja.fish.batch'
+    _description = 'Lote de Peces'
+    _inherit = ['mail.thread', 'mail.activity.mixin']
+
+    name = fields.Char(string='Nombre del lote', required=True, tracking=True)
+    species = fields.Char(string='Especie/Raza', required=True, tracking=True)
+    start_date = fields.Date(string='Fecha de Siembra', required=True, tracking=True)
+    quantity = fields.Integer(string='Cantidad Inicial', required=True, tracking=True)
+    avg_weight = fields.Float(string='Peso Promedio Inicial (g)', tracking=True)
+    company_id = fields.Many2one('res.company', string='Compañía', default=lambda self: self.env.company)
+    active = fields.Boolean(default=True)
+
+class FishTransfer(models.Model):
+    _name = 'piscigranja.fish.transfer'
+    _description = 'Transferencia de Peces'
+
+    date = fields.Date(string='Fecha', default=fields.Date.context_today, required=True)
+    batch_id = fields.Many2one('piscigranja.fish.batch', string='Lote', required=True)
+    source_unit = fields.Char(string='Unidad Origen')
+    dest_unit = fields.Char(string='Unidad Destino')
+    quantity = fields.Integer(string='Cantidad', required=True)
+    notes = fields.Text(string='Notas')
+    company_id = fields.Many2one('res.company', string='Compañía', default=lambda self: self.env.company)
+
+class FishHarvest(models.Model):
+    _name = 'piscigranja.fish.harvest'
+    _description = 'Cosecha de Peces'
+
+    date = fields.Date(string='Fecha', default=fields.Date.context_today, required=True)
+    batch_id = fields.Many2one('piscigranja.fish.batch', string='Lote', required=True)
+    quantity = fields.Integer(string='Cantidad Cosechada', required=True)
+    total_weight = fields.Float(string='Peso Total (kg)')
+    destination = fields.Char(string='Destino')
+    notes = fields.Text(string='Notas')
+    company_id = fields.Many2one('res.company', string='Compañía', default=lambda self: self.env.company)

--- a/addons/piscigranja/models/environment.py
+++ b/addons/piscigranja/models/environment.py
@@ -1,0 +1,15 @@
+from odoo import api, fields, models
+
+class WaterParameter(models.Model):
+    _name = 'piscigranja.water.parameter'
+    _description = 'Lectura de Parámetros de Agua'
+
+    date = fields.Datetime(string='Fecha y Hora', default=fields.Datetime.now, required=True)
+    batch_id = fields.Many2one('piscigranja.fish.batch', string='Lote')
+    unit = fields.Char(string='Unidad')
+    temperature = fields.Float(string='Temperatura (°C)')
+    oxygen = fields.Float(string='Oxígeno Disuelto (mg/L)')
+    ph = fields.Float(string='pH')
+    notes = fields.Text(string='Notas')
+    sensor_uid = fields.Char(string='ID Sensor')  # Placeholder for future IoT integration
+    company_id = fields.Many2one('res.company', string='Compañía', default=lambda self: self.env.company)

--- a/addons/piscigranja/models/feed.py
+++ b/addons/piscigranja/models/feed.py
@@ -1,0 +1,13 @@
+from odoo import api, fields, models
+
+class DailyFeeding(models.Model):
+    _name = 'piscigranja.daily.feeding'
+    _description = 'Registro Diario de Alimentación'
+
+    date = fields.Date(string='Fecha', default=fields.Date.context_today, required=True)
+    batch_id = fields.Many2one('piscigranja.fish.batch', string='Lote', required=True)
+    feed_type = fields.Char(string='Tipo de Alimento', required=True)
+    amount_kg = fields.Float(string='Cantidad (kg)', required=True)
+    leftovers = fields.Float(string='Sobrante (kg)')
+    notes = fields.Text(string='Notas')
+    company_id = fields.Many2one('res.company', string='Compañía', default=lambda self: self.env.company)

--- a/addons/piscigranja/models/health.py
+++ b/addons/piscigranja/models/health.py
@@ -1,0 +1,24 @@
+from odoo import api, fields, models
+
+class DailyMortality(models.Model):
+    _name = 'piscigranja.daily.mortality'
+    _description = 'Mortalidad Diaria'
+
+    date = fields.Date(string='Fecha', default=fields.Date.context_today, required=True)
+    batch_id = fields.Many2one('piscigranja.fish.batch', string='Lote', required=True)
+    quantity = fields.Integer(string='Cantidad', required=True)
+    cause = fields.Char(string='Causa')
+    notes = fields.Text(string='Notas')
+    company_id = fields.Many2one('res.company', string='Compañía', default=lambda self: self.env.company)
+
+class HealthTreatment(models.Model):
+    _name = 'piscigranja.health.treatment'
+    _description = 'Tratamiento Sanitario'
+
+    name = fields.Char(string='Nombre', required=True)
+    batch_id = fields.Many2one('piscigranja.fish.batch', string='Lote', required=True)
+    medication = fields.Char(string='Medicamento/Dosis')
+    start_date = fields.Date(string='Inicio', required=True)
+    end_date = fields.Date(string='Fin')
+    notes = fields.Text(string='Notas')
+    company_id = fields.Many2one('res.company', string='Compañía', default=lambda self: self.env.company)

--- a/addons/piscigranja/security/ir.model.access.csv
+++ b/addons/piscigranja/security/ir.model.access.csv
@@ -1,0 +1,13 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+aqua_batch_admin,piscigranja.fish.batch access admin,model_piscigranja_fish_batch,group_aqua_admin,1,1,1,1
+aqua_batch_tech,piscigranja.fish.batch access tech,model_piscigranja_fish_batch,group_aqua_tech,1,1,1,0
+aqua_batch_user,piscigranja.fish.batch access user,model_piscigranja_fish_batch,group_aqua_user,1,0,1,0
+aqua_feed_admin,piscigranja.daily.feeding access admin,model_piscigranja_daily_feeding,group_aqua_admin,1,1,1,1
+aqua_feed_tech,piscigranja.daily.feeding access tech,model_piscigranja_daily_feeding,group_aqua_tech,1,1,1,0
+aqua_feed_user,piscigranja.daily.feeding access user,model_piscigranja_daily_feeding,group_aqua_user,1,1,1,0
+aqua_mort_admin,piscigranja.daily.mortality access admin,model_piscigranja_daily_mortality,group_aqua_admin,1,1,1,1
+aqua_mort_tech,piscigranja.daily.mortality access tech,model_piscigranja_daily_mortality,group_aqua_tech,1,1,1,0
+aqua_mort_user,piscigranja.daily.mortality access user,model_piscigranja_daily_mortality,group_aqua_user,1,1,1,0
+aqua_env_admin,piscigranja.water.parameter access admin,model_piscigranja_water_parameter,group_aqua_admin,1,1,1,1
+aqua_env_tech,piscigranja.water.parameter access tech,model_piscigranja_water_parameter,group_aqua_tech,1,1,1,0
+aqua_env_user,piscigranja.water.parameter access user,model_piscigranja_water_parameter,group_aqua_user,1,1,1,0

--- a/addons/piscigranja/security/piscigranja_rules.xml
+++ b/addons/piscigranja/security/piscigranja_rules.xml
@@ -1,0 +1,32 @@
+<odoo>
+    <record id="rule_piscigranja_company" model="ir.rule">
+        <field name="name">Piscigranja company rule</field>
+        <field name="model_id" ref="model_piscigranja_fish_batch"/>
+        <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+        <field name="groups" eval="[(4, ref('piscigranja.group_aqua_user')), (4, ref('piscigranja.group_aqua_tech')), (4, ref('piscigranja.group_aqua_admin'))]"/>
+    </record>
+    <record id="rule_piscigranja_daily_feeding" model="ir.rule">
+        <field name="name">Piscigranja feeding company rule</field>
+        <field name="model_id" ref="model_piscigranja_daily_feeding"/>
+        <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+        <field name="groups" eval="[(4, ref('piscigranja.group_aqua_user')), (4, ref('piscigranja.group_aqua_tech')), (4, ref('piscigranja.group_aqua_admin'))]"/>
+    </record>
+    <record id="rule_piscigranja_daily_mortality" model="ir.rule">
+        <field name="name">Piscigranja mortality company rule</field>
+        <field name="model_id" ref="model_piscigranja_daily_mortality"/>
+        <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+        <field name="groups" eval="[(4, ref('piscigranja.group_aqua_user')), (4, ref('piscigranja.group_aqua_tech')), (4, ref('piscigranja.group_aqua_admin'))]"/>
+    </record>
+    <record id="rule_piscigranja_health_treatment" model="ir.rule">
+        <field name="name">Piscigranja treatment company rule</field>
+        <field name="model_id" ref="model_piscigranja_health_treatment"/>
+        <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+        <field name="groups" eval="[(4, ref('piscigranja.group_aqua_user')), (4, ref('piscigranja.group_aqua_tech')), (4, ref('piscigranja.group_aqua_admin'))]"/>
+    </record>
+    <record id="rule_piscigranja_water_parameter" model="ir.rule">
+        <field name="name">Piscigranja water parameter company rule</field>
+        <field name="model_id" ref="model_piscigranja_water_parameter"/>
+        <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+        <field name="groups" eval="[(4, ref('piscigranja.group_aqua_user')), (4, ref('piscigranja.group_aqua_tech')), (4, ref('piscigranja.group_aqua_admin'))]"/>
+    </record>
+</odoo>

--- a/addons/piscigranja/security/piscigranja_security.xml
+++ b/addons/piscigranja/security/piscigranja_security.xml
@@ -1,0 +1,13 @@
+<odoo>
+    <record id="group_aqua_admin" model="res.groups">
+        <field name="name">Administrador Piscigranja</field>
+        <field name="category_id" ref="base.module_category_hidden"/>
+    </record>
+    <record id="group_aqua_tech" model="res.groups">
+        <field name="name">Técnico Piscigranja</field>
+        <field name="implied_ids" eval="[(4, ref('group_aqua_admin'))]"/>
+    </record>
+    <record id="group_aqua_user" model="res.groups">
+        <field name="name">Operario Piscigranja</field>
+    </record>
+</odoo>

--- a/addons/piscigranja/views/cycle_views.xml
+++ b/addons/piscigranja/views/cycle_views.xml
@@ -1,0 +1,40 @@
+<odoo>
+    <record id="view_fish_batch_tree" model="ir.ui.view">
+        <field name="name">piscigranja.fish.batch.tree</field>
+        <field name="model">piscigranja.fish.batch</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="species"/>
+                <field name="start_date"/>
+                <field name="quantity"/>
+            </tree>
+        </field>
+    </record>
+    <record id="view_fish_batch_form" model="ir.ui.view">
+        <field name="name">piscigranja.fish.batch.form</field>
+        <field name="model">piscigranja.fish.batch</field>
+        <field name="arch" type="xml">
+            <form string="Lote de Peces">
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="species"/>
+                        <field name="start_date"/>
+                        <field name="quantity"/>
+                        <field name="avg_weight"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_fish_batch" model="ir.actions.act_window">
+        <field name="name">Lotes de Peces</field>
+        <field name="res_model">piscigranja.fish.batch</field>
+        <field name="view_mode">tree,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">Crear un nuevo lote</p>
+        </field>
+    </record>
+</odoo>

--- a/addons/piscigranja/views/environment_views.xml
+++ b/addons/piscigranja/views/environment_views.xml
@@ -1,0 +1,39 @@
+<odoo>
+    <record id="view_water_parameter_tree" model="ir.ui.view">
+        <field name="name">piscigranja.water.parameter.tree</field>
+        <field name="model">piscigranja.water.parameter</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="date"/>
+                <field name="unit"/>
+                <field name="temperature"/>
+                <field name="oxygen"/>
+                <field name="ph"/>
+            </tree>
+        </field>
+    </record>
+    <record id="view_water_parameter_form" model="ir.ui.view">
+        <field name="name">piscigranja.water.parameter.form</field>
+        <field name="model">piscigranja.water.parameter</field>
+        <field name="arch" type="xml">
+            <form string="Parámetros de Agua">
+                <sheet>
+                    <group>
+                        <field name="date"/>
+                        <field name="batch_id"/>
+                        <field name="unit"/>
+                        <field name="temperature"/>
+                        <field name="oxygen"/>
+                        <field name="ph"/>
+                        <field name="notes"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+    <record id="action_water_parameter" model="ir.actions.act_window">
+        <field name="name">Parámetros de Agua</field>
+        <field name="res_model">piscigranja.water.parameter</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+</odoo>

--- a/addons/piscigranja/views/feed_views.xml
+++ b/addons/piscigranja/views/feed_views.xml
@@ -1,0 +1,37 @@
+<odoo>
+    <record id="view_daily_feeding_tree" model="ir.ui.view">
+        <field name="name">piscigranja.daily.feeding.tree</field>
+        <field name="model">piscigranja.daily.feeding</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="date"/>
+                <field name="batch_id"/>
+                <field name="feed_type"/>
+                <field name="amount_kg"/>
+            </tree>
+        </field>
+    </record>
+    <record id="view_daily_feeding_form" model="ir.ui.view">
+        <field name="name">piscigranja.daily.feeding.form</field>
+        <field name="model">piscigranja.daily.feeding</field>
+        <field name="arch" type="xml">
+            <form string="Alimentación Diaria">
+                <sheet>
+                    <group>
+                        <field name="date"/>
+                        <field name="batch_id"/>
+                        <field name="feed_type"/>
+                        <field name="amount_kg"/>
+                        <field name="leftovers"/>
+                        <field name="notes"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+    <record id="action_daily_feeding" model="ir.actions.act_window">
+        <field name="name">Alimentación</field>
+        <field name="res_model">piscigranja.daily.feeding</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+</odoo>

--- a/addons/piscigranja/views/health_views.xml
+++ b/addons/piscigranja/views/health_views.xml
@@ -1,0 +1,73 @@
+<odoo>
+    <record id="view_daily_mortality_tree" model="ir.ui.view">
+        <field name="name">piscigranja.daily.mortality.tree</field>
+        <field name="model">piscigranja.daily.mortality</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="date"/>
+                <field name="batch_id"/>
+                <field name="quantity"/>
+                <field name="cause"/>
+            </tree>
+        </field>
+    </record>
+    <record id="view_daily_mortality_form" model="ir.ui.view">
+        <field name="name">piscigranja.daily.mortality.form</field>
+        <field name="model">piscigranja.daily.mortality</field>
+        <field name="arch" type="xml">
+            <form string="Mortalidad Diaria">
+                <sheet>
+                    <group>
+                        <field name="date"/>
+                        <field name="batch_id"/>
+                        <field name="quantity"/>
+                        <field name="cause"/>
+                        <field name="notes"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+    <record id="action_daily_mortality" model="ir.actions.act_window">
+        <field name="name">Mortalidades</field>
+        <field name="res_model">piscigranja.daily.mortality</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <record id="view_health_treatment_tree" model="ir.ui.view">
+        <field name="name">piscigranja.health.treatment.tree</field>
+        <field name="model">piscigranja.health.treatment</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="batch_id"/>
+                <field name="medication"/>
+                <field name="start_date"/>
+                <field name="end_date"/>
+            </tree>
+        </field>
+    </record>
+    <record id="view_health_treatment_form" model="ir.ui.view">
+        <field name="name">piscigranja.health.treatment.form</field>
+        <field name="model">piscigranja.health.treatment</field>
+        <field name="arch" type="xml">
+            <form string="Tratamiento">
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="batch_id"/>
+                        <field name="medication"/>
+                        <field name="start_date"/>
+                        <field name="end_date"/>
+                        <field name="notes"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+    <record id="action_health_treatment" model="ir.actions.act_window">
+        <field name="name">Tratamientos</field>
+        <field name="res_model">piscigranja.health.treatment</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+</odoo>

--- a/addons/piscigranja/views/piscigranja_menus.xml
+++ b/addons/piscigranja/views/piscigranja_menus.xml
@@ -1,0 +1,11 @@
+<odoo>
+    <menuitem id="menu_piscigranja_root" name="Piscigranja" sequence="10"/>
+
+    <menuitem id="menu_cycle" name="Ciclo Productivo" parent="menu_piscigranja_root" sequence="10"/>
+    <menuitem id="menu_batches" name="Lotes" parent="menu_cycle" action="action_fish_batch"/>
+    <menuitem id="menu_feeding" name="Alimentación" parent="menu_piscigranja_root" action="action_daily_feeding" sequence="20"/>
+    <menuitem id="menu_health" name="Sanidad" parent="menu_piscigranja_root" sequence="30"/>
+    <menuitem id="menu_mortality" name="Mortalidades" parent="menu_health" action="action_daily_mortality"/>
+    <menuitem id="menu_treatment" name="Tratamientos" parent="menu_health" action="action_health_treatment"/>
+    <menuitem id="menu_environment" name="Ambiental" parent="menu_piscigranja_root" action="action_water_parameter" sequence="40"/>
+</odoo>


### PR DESCRIPTION
## Summary
- add initial 'piscigranja' module for fish farm management
- include models for cycle, feeding, health and environment data
- create security groups, access rules and record rules
- define basic menus and views

## Testing
- `python -m py_compile addons/piscigranja/**/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685750eac29483279068ae7472a7cf58