### PR TITLE
Add veterinary medical history module

### DIFF
--- a/addons/vet_medical_history/__init__.py
+++ b/addons/vet_medical_history/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/vet_medical_history/__manifest__.py
+++ b/addons/vet_medical_history/__manifest__.py
@@ -1,0 +1,12 @@
+{
+    'name': 'Veterinary Medical History',
+    'version': '1.0.0',
+    'category': 'Services',
+    'summary': 'Gestiona historias médicas de pacientes veterinarios',
+    'depends': ['base'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/vet_medical_views.xml',
+    ],
+    'application': True,
+}

--- a/addons/vet_medical_history/models/__init__.py
+++ b/addons/vet_medical_history/models/__init__.py
@@ -1,0 +1,2 @@
+from . import patient
+from . import medical_record

--- a/addons/vet_medical_history/models/medical_record.py
+++ b/addons/vet_medical_history/models/medical_record.py
@@ -1,0 +1,11 @@
+from odoo import fields, models
+
+
+class VetMedicalRecord(models.Model):
+    _name = 'vet.medical.record'
+    _description = 'Veterinary Medical Record'
+
+    patient_id = fields.Many2one('vet.patient', string='Patient', required=True)
+    date = fields.Date(default=fields.Date.context_today)
+    description = fields.Text()
+    treatment = fields.Text()

--- a/addons/vet_medical_history/models/patient.py
+++ b/addons/vet_medical_history/models/patient.py
@@ -1,0 +1,17 @@
+from odoo import fields, models
+
+
+class VetPatient(models.Model):
+    _name = 'vet.patient'
+    _description = 'Veterinary Patient'
+
+    name = fields.Char(required=True)
+    owner_id = fields.Many2one('res.partner', string='Owner')
+    species = fields.Char()
+    breed = fields.Char()
+    age = fields.Integer()
+    medical_record_ids = fields.One2many(
+        'vet.medical.record',
+        'patient_id',
+        string='Medical Records',
+    )

--- a/addons/vet_medical_history/security/ir.model.access.csv
+++ b/addons/vet_medical_history/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_vet_patient,veterinary patient,model_vet_patient,base.group_user,1,1,1,1
+access_vet_medical_record,veterinary medical record,model_vet_medical_record,base.group_user,1,1,1,1

--- a/addons/vet_medical_history/views/vet_medical_views.xml
+++ b/addons/vet_medical_history/views/vet_medical_views.xml
@@ -1,0 +1,90 @@
+<odoo>
+    <record id="view_vet_patient_form" model="ir.ui.view">
+        <field name="name">vet.patient.form</field>
+        <field name="model">vet.patient</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="owner_id"/>
+                        <field name="species"/>
+                        <field name="breed"/>
+                        <field name="age"/>
+                    </group>
+                    <notebook>
+                        <page string="Medical Records">
+                            <field name="medical_record_ids">
+                                <tree editable="bottom">
+                                    <field name="date"/>
+                                    <field name="description"/>
+                                    <field name="treatment"/>
+                                </tree>
+                            </field>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_vet_patient_tree" model="ir.ui.view">
+        <field name="name">vet.patient.tree</field>
+        <field name="model">vet.patient</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="owner_id"/>
+                <field name="species"/>
+                <field name="breed"/>
+                <field name="age"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_vet_medical_record_form" model="ir.ui.view">
+        <field name="name">vet.medical.record.form</field>
+        <field name="model">vet.medical.record</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="patient_id"/>
+                        <field name="date"/>
+                        <field name="description"/>
+                        <field name="treatment"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_vet_medical_record_tree" model="ir.ui.view">
+        <field name="name">vet.medical.record.tree</field>
+        <field name="model">vet.medical.record</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="patient_id"/>
+                <field name="date"/>
+                <field name="description"/>
+                <field name="treatment"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="action_vet_patients" model="ir.actions.act_window">
+        <field name="name">Pacientes</field>
+        <field name="res_model">vet.patient</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <record id="action_vet_medical_records" model="ir.actions.act_window">
+        <field name="name">Historias Médicas</field>
+        <field name="res_model">vet.medical.record</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <menuitem id="menu_vet_root" name="Veterinaria"/>
+    <menuitem id="menu_vet_patients" name="Pacientes" parent="menu_vet_root" action="action_vet_patients"/>
+    <menuitem id="menu_vet_medical_records" name="Historias Médicas" parent="menu_vet_root" action="action_vet_medical_records"/>
+</odoo>


### PR DESCRIPTION
## Summary
- add module to manage veterinary patient medical histories
- introduce patient and medical record models with menus and views

## Testing
- `python -m py_compile addons/vet_medical_history/__init__.py addons/vet_medical_history/models/__init__.py addons/vet_medical_history/models/patient.py addons/vet_medical_history/models/medical_record.py`
- `pytest addons/vet_medical_history -q`


------
https://chatgpt.com/codex/tasks/task_e_68c43e6391a88327b1222a7df0b936f9